### PR TITLE
Fix license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "mpociot/documentarian",
   "description": "",
   "keywords": [],
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "authors": [
     {
       "name": "Marcel Pociot",


### PR DESCRIPTION
Currently the license identifier does not comform to the SPDX list of valid identifiers. Having a valid identifier helps automated license checking tools verify your package.