### PR TITLE
Limited logo max-width to 100% for HiDPI support

### DIFF
--- a/resources/stylus/style.styl
+++ b/resources/stylus/style.styl
@@ -74,6 +74,7 @@ embossed-bg()
   // This is the logo at the top of the ToC
   & > img
     display: block
+    max-width: 100%;
   & > .search
     position: relative
     input


### PR DESCRIPTION
Added `max-width` to logo to support larger image file, so that it doesn't look blurry on HiDPI displays