### PR TITLE
add CI build for php 7.1 and 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ php:
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
+  - 7.2
 
 before_script:
   - travis_retry composer self-update


### PR DESCRIPTION
The CI is failing to php 5.5 because the link `https://storage.googleapis.com/travis-ci-language-archives/php/binaries/ubuntu/16.04/x86_64/php-5.5.tar.bz2` seens to be broken