### PR TITLE
Adds a class selector and alt tag of the page title to the logo

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -27,7 +27,7 @@
       </span>
     </a>
     <div class="tocify-wrapper">
-        <img src="images/logo.png" />
+        <img src="images/logo.png" class="page-logo" alt="{{$page['title']}}" />
         @if(isset($page['language_tabs']))
             <div class="lang-selector">
                 @foreach($page['language_tabs'] as $lang)

--- a/tests/assertions/test1.html
+++ b/tests/assertions/test1.html
@@ -20,7 +20,7 @@
       </span>
     </a>
     <div class="tocify-wrapper">
-        <img src="images/logo.png" />
+        <img src="images/logo.png" class="page-logo" alt="" />
                       <div id="toc">
       </div>
             </div>

--- a/tests/assertions/test2.html
+++ b/tests/assertions/test2.html
@@ -25,7 +25,7 @@
       </span>
     </a>
     <div class="tocify-wrapper">
-        <img src="images/logo.png" />
+        <img src="images/logo.png" class="page-logo" alt="Test" />
                     <div class="lang-selector">
                                   <a href="#" data-language-name="bash">bash</a>
                                   <a href="#" data-language-name="ruby">ruby</a>

--- a/tests/assertions/test3.html
+++ b/tests/assertions/test3.html
@@ -25,7 +25,7 @@
       </span>
     </a>
     <div class="tocify-wrapper">
-        <img src="images/logo.png" />
+        <img src="images/logo.png" class="page-logo" alt="Test" />
                     <div class="lang-selector">
                                   <a href="#" data-language-name="bash">bash</a>
                                   <a href="#" data-language-name="ruby">ruby</a>

--- a/tests/assertions/test4.html
+++ b/tests/assertions/test4.html
@@ -25,7 +25,7 @@
       </span>
     </a>
     <div class="tocify-wrapper">
-        <img src="images/logo.png" />
+        <img src="images/logo.png" class="page-logo" alt="Test" />
                     <div class="lang-selector">
                                   <a href="#" data-language-name="bash">bash</a>
                                   <a href="#" data-language-name="ruby">ruby</a>


### PR DESCRIPTION
Targetting the logo with CSS currently requires you go do `.tocify-wrapper > img`. Now you can use `.page-logo`.

I've also added the page title as the alternative text for the logo for better accessibility.