### PR TITLE
Explicitly specifies the logo's width and height

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -27,7 +27,7 @@
       </span>
     </a>
     <div class="tocify-wrapper">
-        <img src="images/logo.png" />
+        <img src="images/logo.png" width="230" height="52" />
         @if(isset($page['language_tabs']))
             <div class="lang-selector">
                 @foreach($page['language_tabs'] as $lang)


### PR DESCRIPTION
This allows us to use a logo that is 2x, i.e., 460 x 104, which will look better on retina displays (Macs).