### PR TITLE
Support for multibyte characters

### DIFF
--- a/resources/js/script.js
+++ b/resources/js/script.js
@@ -151,6 +151,11 @@
   }
 
   function slugify(text){
+    if (/[^\x01-\x7E\xA1-\xDF]/.test(text)) {
+      // If the text contains multibyte characters, do nothing
+      return text.toString();
+    }
+
     return text.toString().toLowerCase()
         .replace(/\s+/g, '-')           // Replace spaces with -
         .replace(/[^\w\-]+/g, '')       // Remove all non-word chars


### PR DESCRIPTION
I am using `mpociot/laravel-apidoc-generator`, and I encountered an event that when I write Japanese comments in `@group` or method comments, all URL hashes in the generated documentation disappear.

The cause is the following line in the `slugify` function.
```javascript
.replace(/[^\w\-]+/g, '') // Remove all non-word char
```

In the Japanese-speaking world, it is more natural not to do any other `replace`, so I would like to simply return the text.
I don't know about other multi-language areas, but I think it's better than disappearing.